### PR TITLE
Dates for Phase 5 release

### DIFF
--- a/LFGMM_TBC_PhaseHelper.lua
+++ b/LFGMM_TBC_PhaseHelper.lua
@@ -26,7 +26,7 @@ TBC_PHASE_RELEASE_DATES = {
   [TBC_PHASES.PHASE_2] = LFGMM_TBC_PhaseHelper_Time({ month = 9, day = 16, year = 2021 }),
   [TBC_PHASES.PHASE_3] = LFGMM_TBC_PhaseHelper_Time({ month = 1, day = 27, year = 2022 }),
   [TBC_PHASES.PHASE_4] = LFGMM_TBC_PhaseHelper_Time({ month = 3, day = 23, year = 2022 }),
-  [TBC_PHASES.PHASE_5] = nil,
+  [TBC_PHASES.PHASE_5] = LFGMM_TBC_PhaseHelper_Time({ month = 5, day = 10, year = 2022 }),
 }
 
 function LFGMM_TBC_PhaseHelper_EnableFor(tbcPhase)


### PR DESCRIPTION
Adding date for phase 5 release.  Technically Sunwell Plateau doesn't release until 5/12, but since Magisters' Terrance is out, we might as well just make it now.